### PR TITLE
Create global search bar

### DIFF
--- a/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.html
+++ b/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.html
@@ -1,17 +1,11 @@
 <div data-testid="app-issues-deleted">
-  <mat-grid-list cols="3" rowHeight="80px">
+  <mat-grid-list cols="2" rowHeight="80px">
     <mat-grid-tile>
       <div class="grid-flush-left">
         <h1 class="mat-headline" style="margin: 0px">
           {{ userService.currentUser.role === 'Student' ? 'Issues you deleted' : 'All Deleted Issues' }}
         </h1>
       </div>
-    </mat-grid-tile>
-
-    <mat-grid-tile>
-      <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
-      </mat-form-field>
     </mat-grid-tile>
   </mat-grid-list>
 

--- a/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.ts
+++ b/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { PermissionService } from '../../core/services/permission.service';
 import { UserService } from '../../core/services/user.service';
 import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
@@ -14,6 +14,7 @@ export class IssuesDeletedComponent implements OnInit {
   readonly displayedColumns = [TABLE_COLUMNS.NO, TABLE_COLUMNS.TITLE, TABLE_COLUMNS.TYPE, TABLE_COLUMNS.SEVERITY, TABLE_COLUMNS.ACTIONS];
   readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.FIX_ISSUE, ACTION_BUTTONS.RESTORE_ISSUE];
   filter: (issue: Issue) => boolean;
+  @Input() filterValue: string;
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
@@ -25,7 +26,13 @@ export class IssuesDeletedComponent implements OnInit {
     };
   }
 
+  ngOnChanges() {
+    this.applyFilter(this.filterValue || '');
+  }
+
   applyFilter(filterValue: string) {
-    this.table.issues.filter = filterValue;
+    if (this.table && this.table.issues) {
+      this.table.issues.filter = filterValue;
+    }
   }
 }

--- a/src/app/phase-bug-reporting/issues-posted/issues-posted.component.html
+++ b/src/app/phase-bug-reporting/issues-posted/issues-posted.component.html
@@ -1,17 +1,11 @@
 <div data-testid="app-issues-posted">
-  <mat-grid-list cols="3" rowHeight="80px">
+  <mat-grid-list cols="2" rowHeight="80px">
     <mat-grid-tile>
       <div class="grid-flush-left">
         <h1 class="mat-headline" style="margin: 0px">
           {{ userService.currentUser.role === 'Student' ? 'Issues you posted' : 'All Issues' }}
         </h1>
       </div>
-    </mat-grid-tile>
-
-    <mat-grid-tile>
-      <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
-      </mat-form-field>
     </mat-grid-tile>
 
     <mat-grid-tile>

--- a/src/app/phase-bug-reporting/issues-posted/issues-posted.component.ts
+++ b/src/app/phase-bug-reporting/issues-posted/issues-posted.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, Input, SimpleChanges } from '@angular/core';
 import { PermissionService } from '../../core/services/permission.service';
 import { UserService } from '../../core/services/user.service';
 import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
@@ -14,6 +14,7 @@ export class IssuesPostedComponent implements OnInit {
   readonly displayedColumns = [TABLE_COLUMNS.NO, TABLE_COLUMNS.TITLE, TABLE_COLUMNS.TYPE, TABLE_COLUMNS.SEVERITY, TABLE_COLUMNS.ACTIONS];
   readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.DELETE_ISSUE, ACTION_BUTTONS.FIX_ISSUE];
   filter: (issue: Issue) => boolean;
+  @Input() filterValue: string;
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
@@ -25,7 +26,13 @@ export class IssuesPostedComponent implements OnInit {
     };
   }
 
+  ngOnChanges() {
+    this.applyFilter(this.filterValue || '');
+  }
+
   applyFilter(filterValue: string) {
-    this.table.issues.filter = filterValue;
+    if (this.table && this.table.issues) {
+      this.table.issues.filter = filterValue;
+    }
   }
 }

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.html
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.html
@@ -1,4 +1,5 @@
 <div>
-  <app-issues-posted></app-issues-posted>
-  <app-issues-deleted></app-issues-deleted>
+  <app-global-search (search)="onGlobalSearch($event)"></app-global-search>
+  <app-issues-posted [filterValue]="globalSearchValue"></app-issues-posted>
+  <app-issues-deleted [filterValue]="globalSearchValue"></app-issues-deleted>
 </div>

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
@@ -9,6 +9,11 @@ import { UserService } from '../core/services/user.service';
 })
 export class PhaseBugReportingComponent implements OnInit {
   constructor(public permissions: PermissionService, public userService: UserService) {}
+  globalSearchValue = '';
+
+  onGlobalSearch(value: string) {
+    this.globalSearchValue = value;
+  }
 
   ngOnInit() {}
 }

--- a/src/app/phase-bug-reporting/phase-bug-reporting.module.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.module.ts
@@ -12,6 +12,7 @@ import { PhaseBugReportingRoutingModule } from './phase-bug-reporting-routing.mo
 import { PhaseBugReportingComponent } from './phase-bug-reporting.component';
 import { IssuesPostedComponent } from './issues-posted/issues-posted.component';
 import { IssuesDeletedComponent } from './issues-deleted/issues-deleted.component';
+import { GlobalSearchModule } from '../shared/global-search/global-search.module';
 
 @NgModule({
   imports: [
@@ -22,7 +23,8 @@ import { IssuesDeletedComponent } from './issues-deleted/issues-deleted.componen
     ViewIssueModule,
     MarkdownModule.forChild(),
     IssueTablesModule,
-    LabelDropdownModule
+    LabelDropdownModule,
+    GlobalSearchModule
   ],
   declarations: [PhaseBugReportingComponent, NewIssueComponent, IssueComponent, IssuesPostedComponent, IssuesDeletedComponent]
 })

--- a/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.html
+++ b/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.html
@@ -1,17 +1,11 @@
 <div data-testid="app-issues-deleted">
-  <mat-grid-list cols="3" rowHeight="80px">
+  <mat-grid-list cols="2" rowHeight="80px">
     <mat-grid-tile>
       <div class="grid-flush-left">
         <h1 class="mat-headline" style="margin: 0px">
           {{ userService.currentUser.role === 'Student' ? 'Issues you deleted' : 'All Deleted Issues' }}
         </h1>
       </div>
-    </mat-grid-tile>
-
-    <mat-grid-tile>
-      <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
-      </mat-form-field>
     </mat-grid-tile>
   </mat-grid-list>
 

--- a/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.ts
+++ b/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { PermissionService } from '../../core/services/permission.service';
 import { UserService } from '../../core/services/user.service';
 import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
@@ -14,6 +14,7 @@ export class IssuesDeletedComponent implements OnInit {
   readonly displayedColumns = [TABLE_COLUMNS.NO, TABLE_COLUMNS.TITLE, TABLE_COLUMNS.TYPE, TABLE_COLUMNS.SEVERITY, TABLE_COLUMNS.ACTIONS];
   readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.FIX_ISSUE, ACTION_BUTTONS.RESTORE_ISSUE];
   filter: (issue: Issue) => boolean;
+  @Input() filterValue: string;
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
@@ -25,7 +26,13 @@ export class IssuesDeletedComponent implements OnInit {
     };
   }
 
+  ngOnChanges() {
+    this.applyFilter(this.filterValue || '');
+  }
+
   applyFilter(filterValue: string) {
-    this.table.issues.filter = filterValue;
+    if (this.table && this.table.issues) {
+      this.table.issues.filter = filterValue;
+    }
   }
 }

--- a/src/app/phase-bug-trimming/issues-posted/issues-posted.component.html
+++ b/src/app/phase-bug-trimming/issues-posted/issues-posted.component.html
@@ -1,17 +1,11 @@
 <div data-testid="app-issues-posted">
-  <mat-grid-list cols="3" rowHeight="80px">
+  <mat-grid-list cols="2" rowHeight="80px">
     <mat-grid-tile>
       <div class="grid-flush-left">
         <h1 class="mat-headline" style="margin: 0px">
           {{ userService.currentUser.role === 'Student' ? 'Issues you posted' : 'All Issues' }}
         </h1>
       </div>
-    </mat-grid-tile>
-
-    <mat-grid-tile>
-      <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
-      </mat-form-field>
     </mat-grid-tile>
 
     <mat-grid-tile>

--- a/src/app/phase-bug-trimming/issues-posted/issues-posted.component.ts
+++ b/src/app/phase-bug-trimming/issues-posted/issues-posted.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { PermissionService } from '../../core/services/permission.service';
 import { UserService } from '../../core/services/user.service';
 import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
@@ -14,6 +14,7 @@ export class IssuesPostedComponent implements OnInit {
   readonly displayedColumns = [TABLE_COLUMNS.NO, TABLE_COLUMNS.TITLE, TABLE_COLUMNS.TYPE, TABLE_COLUMNS.SEVERITY, TABLE_COLUMNS.ACTIONS];
   readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.DELETE_ISSUE, ACTION_BUTTONS.FIX_ISSUE];
   filter: (issue: Issue) => boolean;
+  @Input() filterValue: string;
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
@@ -25,7 +26,13 @@ export class IssuesPostedComponent implements OnInit {
     };
   }
 
+  ngOnChanges() {
+    this.applyFilter(this.filterValue || '');
+  }
+
   applyFilter(filterValue: string) {
-    this.table.issues.filter = filterValue;
+    if (this.table && this.table.issues) {
+      this.table.issues.filter = filterValue;
+    }
   }
 }

--- a/src/app/phase-bug-trimming/phase-bug-trimming.component.html
+++ b/src/app/phase-bug-trimming/phase-bug-trimming.component.html
@@ -1,4 +1,5 @@
 <div>
-  <app-issues-posted></app-issues-posted>
-  <app-issues-deleted></app-issues-deleted>
+  <app-global-search (search)="onGlobalSearch($event)"></app-global-search>
+  <app-issues-posted [filterValue]="globalSearchValue"></app-issues-posted>
+  <app-issues-deleted [filterValue]="globalSearchValue"></app-issues-deleted>
 </div>

--- a/src/app/phase-bug-trimming/phase-bug-trimming.component.ts
+++ b/src/app/phase-bug-trimming/phase-bug-trimming.component.ts
@@ -9,6 +9,11 @@ import { UserService } from '../core/services/user.service';
 })
 export class PhaseBugTrimmingComponent implements OnInit {
   constructor(public permissions: PermissionService, public userService: UserService) {}
+  globalSearchValue = '';
 
   ngOnInit(): void {}
+
+  onGlobalSearch(value: string) {
+    this.globalSearchValue = value;
+  }
 }

--- a/src/app/phase-bug-trimming/phase-bug-trimming.module.ts
+++ b/src/app/phase-bug-trimming/phase-bug-trimming.module.ts
@@ -7,9 +7,10 @@ import { ViewIssueModule } from '../shared/view-issue/view-issue.module';
 import { IssuesDeletedComponent } from './issues-deleted/issues-deleted.component';
 import { IssuesPostedComponent } from './issues-posted/issues-posted.component';
 import { IssueTablesModule } from '../shared/issue-tables/issue-tables.module';
+import { GlobalSearchModule } from '../shared/global-search/global-search.module';
 
 @NgModule({
-  imports: [PhaseBugTrimmingRoutingModule, SharedModule, ViewIssueModule, IssueTablesModule],
+  imports: [PhaseBugTrimmingRoutingModule, SharedModule, ViewIssueModule, IssueTablesModule, GlobalSearchModule],
   declarations: [PhaseBugTrimmingComponent, IssueComponent, IssuesDeletedComponent, IssuesPostedComponent]
 })
 export class PhaseBugTrimmingModule {}

--- a/src/app/shared/global-search/global-search.component.css
+++ b/src/app/shared/global-search/global-search.component.css
@@ -1,0 +1,9 @@
+.global-search-container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 16px;
+}
+mat-form-field {
+  width: 80%;
+}

--- a/src/app/shared/global-search/global-search.component.html
+++ b/src/app/shared/global-search/global-search.component.html
@@ -1,0 +1,5 @@
+<div class="global-search-container">
+  <mat-form-field>
+    <input matInput [(ngModel)]="searchValue" (keyup)="onSearchChange(searchValue)" placeholder="Search issues" />
+  </mat-form-field>
+</div>

--- a/src/app/shared/global-search/global-search.component.ts
+++ b/src/app/shared/global-search/global-search.component.ts
@@ -1,0 +1,16 @@
+import { Component, Output, EventEmitter } from '@angular/core';
+
+@Component({
+  selector: 'app-global-search',
+  templateUrl: './global-search.component.html',
+  styleUrls: ['./global-search.component.css']
+})
+export class GlobalSearchComponent {
+  searchValue = '';
+  @Output() search = new EventEmitter<string>();
+
+  onSearchChange(value: string) {
+    this.searchValue = value;
+    this.search.emit(this.searchValue);
+  }
+}

--- a/src/app/shared/global-search/global-search.module.ts
+++ b/src/app/shared/global-search/global-search.module.ts
@@ -1,0 +1,13 @@
+import { GlobalSearchComponent } from './global-search.component';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+
+@NgModule({
+  declarations: [GlobalSearchComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, MatInputModule, MatFormFieldModule],
+  exports: [GlobalSearchComponent]
+})
+export class GlobalSearchModule {}


### PR DESCRIPTION
The PR combines the individual search bars of the issues posted table and issues deleted table into a single search bar, that will filter through issues in both tables of the bug reporting phase and the bug trimming phase. 

This enhancement streamlines bug searching by allowing students to search both tables simultaneously, helping to identify duplicate or similar issues more efficiently in both tables. It could also be extended to the team response phase, where there is a high likelihood of duplicate bugs to triage. 

The combined search bar is able to filter the tables by name, severity, or label, similar to the individual search bars. This is shown in the screenshots below: 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/c717a757-bb68-4dd6-83ae-0f769c62271c" />

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/258e36d0-552c-4896-8423-734218897bfa" />

The search bar works as intended when tested manually, but fails the end-to-end tests for searching for issues in the bug reporting and bug trimming phases (because the original search bars were removed)